### PR TITLE
Make force/circle graphs behave better

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -511,8 +511,6 @@ background-color: #eceff3;
  border-top-color: #eceff3;
 }
 
-/*
-.form-control:focus {
-        border-color: #36c9da;
-    }
-
+.tab-pane.active {
+ overflow: hidden;
+}

--- a/www/javascript/circleNetwork.js
+++ b/www/javascript/circleNetwork.js
@@ -24,12 +24,29 @@ binding.renderValue = function(el, data) {
     var mainsvg = d3.select("#" + $(el).attr('id')).append("svg")
       .attr("width", width)
       .attr("height", height)
-      .attr("xmlns","http://www.w3.org/2000/svg")
-      .call(d3.behavior.zoom().on("zoom", redraw))
+      .attr("xmlns","http://www.w3.org/2000/svg");
+
+    var rtx = radius + 70,
+        rty = radius;
 
     var svg = mainsvg
       .append("g")
-      .attr("transform", "translate(" + (radius + 70) + "," + radius + ")");
+      .attr("transform", "translate(" + rtx + "," + rty + ")");	
+
+    var zoom = d3.behavior.zoom()
+      .scaleExtent([1, 10])
+      .translate([rtx, rty])
+      .on("zoom", function() {
+        var e = d3.event,
+            tx = e.translate[0]
+            ty = e.translate[1];
+        zoom.translate([tx, ty]);
+        svg.attr(
+          "transform",
+          "translate(" + [tx, ty] + ")" + " scale(" + e.scale + ")"
+        );
+    });
+    mainsvg.call(zoom);
 
     d3.json($(el).attr('jsonfilename'), function(error, root) {
 
@@ -101,9 +118,6 @@ binding.renderValue = function(el, data) {
           .attr("font-size", function(d) { return d.textsize; });
     }
 
-    function redraw() {
-      mainsvg.attr("transform", "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")");
-    }
 
     d3.select(self.frameElement).style("height", radius * 2 + "px");
 

--- a/www/javascript/collapsableForceNetwork.js
+++ b/www/javascript/collapsableForceNetwork.js
@@ -27,7 +27,20 @@ binding.renderValue = function(el, data) {
           .attr("width", width)
           .attr("height", height)
           .attr("xmlns","http://www.w3.org/2000/svg")
-          .call(d3.behavior.zoom().on("zoom", redraw));
+          .call(
+            d3.behavior.zoom()
+            .scaleExtent([1, 5])
+            .on("zoom", function() {
+              svg.attr(
+                "transform",
+                "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")"
+              );
+            })
+	  );
+
+      function redraw() {
+        svg.attr("transform", "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")");
+      }
 
       var link = svg.selectAll(".link");
           node = svg.selectAll(".node");
@@ -165,9 +178,6 @@ binding.renderValue = function(el, data) {
         return nodes;
       }
 
-      function redraw() {
-        svg.attr("transform", "translate(" + d3.event.translate + ")" + " scale(" + d3.event.scale + ")");
-      }
   //closing if statement
   }
 //closing binding


### PR DESCRIPTION
Context: #15 

The overflown elements issue was fixed via a simple CSS style change.

The zoom/pan behaves better since we now:
- enforce a min/max zoom scale (so that people won't zoom in/out too much by mistake)
- translate mouse events better (so that the graphs don't jump around while interacting)

![screen recording 2018-06-20 at 11 47 am](https://user-images.githubusercontent.com/7809/41669394-b686eeaa-747f-11e8-8fcf-00a0638bc1a1.gif)
